### PR TITLE
Create config.yml to enable wide charater.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,1 @@
+charset: "UTF-8"


### PR DESCRIPTION
If heroku logs says "Wide character in syswrite at /app/local/lib/perl5/Starman/Server.pm", this can solve the problem.
